### PR TITLE
fix numerical underflow in predict.naive_bayes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,4 +10,5 @@ BugReports: http://github.com/majkamichal/naivebayes/issues
 License: GPL-2
 Encoding: UTF-8
 NeedsCompilation: no
-
+Imports: matrixStats (>= 0.54.0)
+Suggests: testthat

--- a/R/predict.naive_bayes.R
+++ b/R/predict.naive_bayes.R
@@ -61,21 +61,28 @@ predict.naive_bayes <- function(object, newdata = NULL, type = c("class", "prob"
         }
     } else {
         if (n_obs == 1) {
-            lik <- exp(log_sum + log(prior))
-            post <- sapply(lik, function(prob) {
-                prob / sum(lik)
-            })
+            # lik <- exp(log_sum + log(prior))
+            # post <- sapply(lik, function(prob) {
+            #     prob / sum(lik)
+            # })
+            lik<-log_sum+log(prior)
+            post<-exp(lik-matrixStats::logSumExp(lik))
             mat <- t(as.matrix(post))
             colnames(mat) <- lev
             return(mat)
         } else {
-            lik <- exp(t(t(log_sum) + log(prior)))
+            # lik <- exp(t(t(log_sum) + log(prior)))
+            lik<-t(t(log_sum) + log(prior))
+            #lik has rows=observations, cols=outcome categories
             dimnames(lik) <- NULL
-            rs <- rowSums(lik)
+            # rs <- rowSums(lik)
+            rs<- matrixStats::rowLogSumExps(lik)
             colnames(lik) <- lev
-            return(apply(lik, 2, function(prob) {
-                prob / rs
-            }))
+            # return(apply(lik, 2, function(prob) {
+            #     prob / rs
+            # }))
+            post<-exp(lik-rs) #recycles the vector rs across matrix lik
+            return(post)
         }
     }
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,5 @@
+library(testthat)
+library(naivebayes)
+
+test_check("naivebayes")
+

--- a/tests/testthat/test_naivebayes.R
+++ b/tests/testthat/test_naivebayes.R
@@ -1,0 +1,34 @@
+library(naivebayes)
+n<-50; k<-1000
+X<-matrix(rnorm(n*k),nrow=n)
+b<-rnorm(k)
+eta<-drop(X%*%b)
+eta<-eta-mean(eta)
+y<-rbinom(n,1,plogis(eta))
+tr_idx<-1:floor(.8*n)
+Xtrn<-X[tr_idx,]
+ytrn<-y[tr_idx]
+Xtst<-X[-tr_idx,]
+ytst<-y[-tr_idx]
+fit<-naive_bayes(Xtrn,ytrn,usekernel=TRUE)
+preds<-as.character(predict(fit,Xtst,type="class"))
+#n_obs==1 case
+probs1<-predict(fit,t(as.matrix(Xtst[1,])),type="prob")
+#n_obs>1 case
+probs2<-predict(fit,Xtst,type="prob")
+preds2<-apply(probs2,1,which.max)
+# maxprobs<-apply(probs2,1,max)
+preds2<-colnames(probs2)[preds2]
+
+test_that("posterior probabilities not NaN", {
+    expect_false(any(is.nan(probs1)),info="n_obs=1")
+    expect_false(any(is.nan(probs2)),info="n_obs>1")
+})
+
+test_that("posterior probabilities sum to 1", {
+    expect_equal(rowSums(probs2),rep(1,nrow(probs2)))
+})
+
+test_that("probability predictions consistent with class predictions", {
+    expect_equal(preds2,preds)
+})


### PR DESCRIPTION
by using logSumExp from package matrixStats, adds automated tests. Addresses #4 